### PR TITLE
fix : updating base url should also update derived urls

### DIFF
--- a/paytmpg/pg/constants/MerchantProperty.py
+++ b/paytmpg/pg/constants/MerchantProperty.py
@@ -118,6 +118,10 @@ class MerchantProperty:
     @classmethod
     def set_base_url(cls, base_url):
         cls.base_url = base_url
+        cls.initiate_txn_url = cls.base_url + "/order/initiate"
+        cls.refund_url = cls.base_url + "/refund/apply"
+        cls.payment_status_url = cls.base_url + "/v3/order/status"
+        cls.refund_status_url = cls.base_url + "/v2/refund/status"
 
     @classmethod
     def get_base_url(cls):


### PR DESCRIPTION
Current SDK seems outdated.

I am not sure if current base url (https://securestage.paytmpayments.com) works for others or not but for my merchant credentials another url is working which is : https://securegw-stage.paytm.in

I tried to play with SDK by setting base url but it didn't update the urls which are derived from base_url. I have updated the function set_base_url to take care of that.